### PR TITLE
Exclude stylecop from package

### DIFF
--- a/src/FubarDev.WebDavServer.AspNetCore/FubarDev.WebDavServer.AspNetCore.csproj
+++ b/src/FubarDev.WebDavServer.AspNetCore/FubarDev.WebDavServer.AspNetCore.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Version="2.0.2" />
     <PackageReference Include="Scrutor" Version="2.2.1" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(ProjectDir)..\..\WebDavServer.ruleset" Link="WebDavServer.ruleset" />

--- a/src/FubarDev.WebDavServer.FileSystem.DotNet/FubarDev.WebDavServer.FileSystem.DotNet.csproj
+++ b/src/FubarDev.WebDavServer.FileSystem.DotNet/FubarDev.WebDavServer.FileSystem.DotNet.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="All"  />
     <PackageReference Include="System.Interactive.Async" Version="3.1.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/FubarDev.WebDavServer.FileSystem.InMemory/FubarDev.WebDavServer.FileSystem.InMemory.csproj
+++ b/src/FubarDev.WebDavServer.FileSystem.InMemory/FubarDev.WebDavServer.FileSystem.InMemory.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FubarDev.WebDavServer\FubarDev.WebDavServer.csproj" />

--- a/src/FubarDev.WebDavServer.FileSystem.SQLite/FubarDev.WebDavServer.FileSystem.SQLite.csproj
+++ b/src/FubarDev.WebDavServer.FileSystem.SQLite/FubarDev.WebDavServer.FileSystem.SQLite.csproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
     <PackageReference Include="sqlite-net-pcl" Version="1.4.118" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FubarDev.WebDavServer\FubarDev.WebDavServer.csproj" />

--- a/src/FubarDev.WebDavServer.Locking.InMemory/FubarDev.WebDavServer.Locking.InMemory.csproj
+++ b/src/FubarDev.WebDavServer.Locking.InMemory/FubarDev.WebDavServer.Locking.InMemory.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FubarDev.WebDavServer\FubarDev.WebDavServer.csproj" />

--- a/src/FubarDev.WebDavServer.Locking.SQLite/FubarDev.WebDavServer.Locking.SQLite.csproj
+++ b/src/FubarDev.WebDavServer.Locking.SQLite/FubarDev.WebDavServer.Locking.SQLite.csproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
     <PackageReference Include="sqlite-net-pcl" Version="1.4.118" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FubarDev.WebDavServer\FubarDev.WebDavServer.csproj" />

--- a/src/FubarDev.WebDavServer.Props.Store.InMemory/FubarDev.WebDavServer.Props.Store.InMemory.csproj
+++ b/src/FubarDev.WebDavServer.Props.Store.InMemory/FubarDev.WebDavServer.Props.Store.InMemory.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FubarDev.WebDavServer\FubarDev.WebDavServer.csproj" />

--- a/src/FubarDev.WebDavServer.Props.Store.SQLite/FubarDev.WebDavServer.Props.Store.SQLite.csproj
+++ b/src/FubarDev.WebDavServer.Props.Store.SQLite/FubarDev.WebDavServer.Props.Store.SQLite.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageReference Include="sqlite-net-pcl" Version="1.4.118" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FubarDev.WebDavServer\FubarDev.WebDavServer.csproj" />

--- a/src/FubarDev.WebDavServer.Props.Store.TextFile/FubarDev.WebDavServer.Props.Store.TextFile.csproj
+++ b/src/FubarDev.WebDavServer.Props.Store.TextFile/FubarDev.WebDavServer.Props.Store.TextFile.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
     <PackageReference Include="Polly" Version="5.8.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FubarDev.WebDavServer\FubarDev.WebDavServer.csproj" />

--- a/src/FubarDev.WebDavServer/FubarDev.WebDavServer.csproj
+++ b/src/FubarDev.WebDavServer/FubarDev.WebDavServer.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="All" />
     <PackageReference Include="System.Buffers" Version="4.4.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
     <PackageReference Include="System.Interactive.Async" Version="3.1.1" />

--- a/test/FubarDev.WebDavServer.Tests/FubarDev.WebDavServer.Tests.csproj
+++ b/test/FubarDev.WebDavServer.Tests/FubarDev.WebDavServer.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="MimeKitLite" Version="2.0.1" />
     <PackageReference Include="PortableWebDavLibrary" Version="1.1.7" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="All" />
     <PackageReference Include="System.Xml.XPath.XDocument" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />


### PR DESCRIPTION
StyleCop is only required for build time, so exclude it from final package dependency.