### PR TITLE
Improved logic for retrieving the controller-relative URL (fixes #53)

### DIFF
--- a/src/FubarDev.WebDavServer.AspNetCore/WebDavContext.cs
+++ b/src/FubarDev.WebDavServer.AspNetCore/WebDavContext.cs
@@ -7,10 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Principal;
 using System.Text;
-using System.Text.RegularExpressions;
-
 using FubarDev.WebDavServer.Utils.UAParser;
-
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -79,17 +76,15 @@ namespace FubarDev.WebDavServer.AspNetCore
                 () =>
                 {
                     var path = httpContextAccessor.HttpContext.GetRouteValue("path")?.ToString();
-                    var input = ServiceAbsoluteRequestUrl.ToString();
-                    string remaining;
+                    var input = Uri.UnescapeDataString(ServiceAbsoluteRequestUrl.ToString());
+                    string remaining = input;
                     if (path != null)
                     {
-                        var uriPath = path.UriEscape();
-                        var pattern = string.Format("{0}$", Regex.Escape(uriPath));
-                        remaining = Regex.Replace(input, pattern, string.Empty);
-                    }
-                    else
-                    {
-                        remaining = input;
+                        int pathIndex = input.LastIndexOf(path, StringComparison.Ordinal);
+                        if (pathIndex != -1)
+                        {
+                            remaining = input.Substring(0, pathIndex);
+                        }
                     }
 
                     var serviceControllerAbsoluteUrl = new Uri(remaining);


### PR DESCRIPTION
Here is my approach to change the retrieval of the controller-relative URL to something that works without Regex and is (hopefully) a little bit more safe.

It works well in my application and handles very cryptic directory/file names correctly.