### PR TITLE
Add support for Windows Kerberos/NTLM authentication to the sample app

### DIFF
--- a/sample/FubarDev.WebDavServer.Sample.AspNetCore/FubarDev.WebDavServer.Sample.AspNetCore.csproj
+++ b/sample/FubarDev.WebDavServer.Sample.AspNetCore/FubarDev.WebDavServer.Sample.AspNetCore.csproj
@@ -23,6 +23,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="3.1.21" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="3.1.2" />
     <PackageReference Include="Mono.DllMap" Version="1.0.1" />
     <PackageReference Include="Npam" Version="1.0.2" />

--- a/sample/FubarDev.WebDavServer.Sample.AspNetCore/Program.cs
+++ b/sample/FubarDev.WebDavServer.Sample.AspNetCore/Program.cs
@@ -17,7 +17,7 @@ namespace FubarDev.WebDavServer.Sample.AspNetCore
     public class Program
     {
         public static bool DisableLocking { get; private set; }
-
+        public static bool UseNegotiate { get; private set; }
         public static bool IsKestrel { get; private set; }
 
         public static bool DisableBasicAuth { get; private set; }
@@ -72,7 +72,7 @@ namespace FubarDev.WebDavServer.Sample.AspNetCore
 
             DisableBasicAuth = config.GetValue<bool>("disable-basic-auth");
             DisableLocking = config.GetValue<bool>("disable-locking");
-
+            UseNegotiate = config.GetValue<bool>("use-negotiate");
             return BuildWebHost(
                 args,
                 builder => ConfigureHosting(builder, config));

--- a/sample/FubarDev.WebDavServer.Sample.AspNetCore/Properties/launchSettings.json
+++ b/sample/FubarDev.WebDavServer.Sample.AspNetCore/Properties/launchSettings.json
@@ -16,7 +16,7 @@
     },
     "SQLite/Kestrel": {
       "commandName": "Project",
-      "commandLineArgs": "--use-kestrel=true --Server:FileSystem=SQLite --Server:PropertyStore=SQLite --Server:LockManager=SQLite --disable-basic-auth=true",
+      "commandLineArgs": "--use-kestrel=true --Server:FileSystem=SQLite --Server:PropertyStore=SQLite --Server:LockManager=SQLite",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/sample/FubarDev.WebDavServer.Sample.AspNetCore/Properties/launchSettings.json
+++ b/sample/FubarDev.WebDavServer.Sample.AspNetCore/Properties/launchSettings.json
@@ -45,15 +45,6 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "applicationUrl": "http://*:5809/"
-    },
-    "WSL": {
-      "commandName": "WSL2",
-      "launchUrl": "http://localhost:5809/",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_URLS": "http://localhost:5809/"
-      },
-      "distributionName": ""
     }
   }
 }

--- a/sample/FubarDev.WebDavServer.Sample.AspNetCore/Properties/launchSettings.json
+++ b/sample/FubarDev.WebDavServer.Sample.AspNetCore/Properties/launchSettings.json
@@ -16,7 +16,15 @@
     },
     "SQLite/Kestrel": {
       "commandName": "Project",
-      "commandLineArgs": "--use-kestrel=true --Server:FileSystem=SQLite --Server:PropertyStore=SQLite --Server:LockManager=SQLite",
+      "commandLineArgs": "--use-kestrel=true --Server:FileSystem=SQLite --Server:PropertyStore=SQLite --Server:LockManager=SQLite --disable-basic-auth=true",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:5809/"
+    },
+    "SQLite/Kestrel/Negotiate": {
+      "commandName": "Project",
+      "commandLineArgs": "--use-kestrel=true --Server:FileSystem=SQLite --Server:PropertyStore=SQLite --Server:LockManager=SQLite --disable-basic-auth=true --use-negotiate=true",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
@@ -37,6 +45,15 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "applicationUrl": "http://*:5809/"
+    },
+    "WSL": {
+      "commandName": "WSL2",
+      "launchUrl": "http://localhost:5809/",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_URLS": "http://localhost:5809/"
+      },
+      "distributionName": ""
     }
   }
 }


### PR DESCRIPTION
This allows Windows explorer and Microsoft Office apps to connect without changing registry settings for basic authentication, and uses Windows credentials to authenticate by using kestrel. 

It adds a new argument "--use-negotiate=true" to enable this behavior.

I have found while testing that if you open an office file from the webdav share, Windows defender will report it as a threat and prevent access to it, unless you disable real-time scanning in Windows Security.

I suspect this might be because the web service URL is not https with a signed certificate (using self-signed certificate doesn't resolve it)
