### PR TITLE
Fix empty response body when debug log is enabled

### DIFF
--- a/src/FubarDev.WebDavServer.AspNetCore/LoggingWebDavResponse.cs
+++ b/src/FubarDev.WebDavServer.AspNetCore/LoggingWebDavResponse.cs
@@ -4,38 +4,39 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 
 using FubarDev.WebDavServer.AspNetCore.Logging;
+using FubarDev.WebDavServer.Utils;
+
+using Microsoft.AspNetCore.Http;
 
 namespace FubarDev.WebDavServer.AspNetCore
 {
     /// <summary>
-    /// A <see cref="IWebDavResponse"/> implementation that buffers the output of a <see cref="IWebDavResult"/>.
+    /// A <see cref="IWebDavResponse"/> implementation that buffers the output of a <see cref="WebDavResponse"/>.
     /// </summary>
-    public class LoggingWebDavResponse : IWebDavResponse
+    public class LoggingWebDavResponse : WebDavResponse
     {
+        private readonly HttpResponse _response;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="LoggingWebDavResponse"/> class.
         /// </summary>
         /// <param name="context">The current WebDAV context.</param>
-        public LoggingWebDavResponse(IWebDavContext context)
+        /// <param name="response">The ASP.NET Core HTTP response.</param>
+        public LoggingWebDavResponse(IWebDavContext context, HttpResponse response)
+            : base(context, response)
         {
-            Context = context;
-            ContentType = "text/xml";
+            _response = response;
         }
 
-        /// <inheritdoc />
-        public IWebDavContext Context { get; }
-
-        /// <inheritdoc />
-        public IDictionary<string, string[]> Headers { get; } = new Dictionary<string, string[]>();
-
-        /// <inheritdoc />
-        public string ContentType { get; set; }
-
-        /// <inheritdoc />
-        public Stream Body { get; } = new MemoryStream();
+        /// <summary>
+        /// Gets the buffered output stream
+        /// </summary>
+        public override Stream Body { get; } = new MemoryStream();
 
         /// <summary>
         /// Loads the <see cref="Body"/> into a <see cref="XDocument"/>.
@@ -62,6 +63,17 @@ namespace FubarDev.WebDavServer.AspNetCore
             {
                 return null;
             }
+        }
+
+        /// <summary>
+        /// Writes the buffered output to the http response body
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the http request</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task WriteBufferedOutPutToResponse(CancellationToken cancellationToken)
+        {
+            Body.Position = 0;
+            await Body.CopyToAsync(_response.Body, SystemInfo.CopyBufferSize, cancellationToken);
         }
     }
 }

--- a/src/FubarDev.WebDavServer.AspNetCore/WebDavIndirectResult.cs
+++ b/src/FubarDev.WebDavServer.AspNetCore/WebDavIndirectResult.cs
@@ -65,7 +65,7 @@ namespace FubarDev.WebDavServer.AspNetCore
 
             if (_logger?.IsEnabled(LogLevel.Debug) ?? false)
             {
-                var loggingResponse = new LoggingWebDavResponse(_context);
+                var loggingResponse = new LoggingWebDavResponse(_context, response);
                 await _result.ExecuteResultAsync(loggingResponse, context.HttpContext.RequestAborted).ConfigureAwait(false);
                 if (!string.IsNullOrEmpty(loggingResponse.ContentType))
                 {
@@ -81,6 +81,9 @@ namespace FubarDev.WebDavServer.AspNetCore
                         }
                     }
                 }
+
+                await loggingResponse.WriteBufferedOutPutToResponse(context.HttpContext.RequestAborted).ConfigureAwait(false);
+                return;
             }
 
             // Writes the XML response

--- a/src/FubarDev.WebDavServer.AspNetCore/WebDavResponse.cs
+++ b/src/FubarDev.WebDavServer.AspNetCore/WebDavResponse.cs
@@ -48,7 +48,7 @@ namespace FubarDev.WebDavServer.AspNetCore
         }
 
         /// <inheritdoc />
-        public Stream Body => _response.Body;
+        public virtual Stream Body => _response.Body;
 
         private class HeadersDictionary : IDictionary<string, string[]>
         {


### PR DESCRIPTION
Change to fix stream already consumed by the LoggingWebDavResponse. Resolves #73 

IWebDavResult now writes the result to the http output except for the body which is buffered in a memory stream. 
The memory stream is then copied to the httpresult body. 

This avoids the executing the result processing twice. 