### PR TITLE
Update scrutor dependency

### DIFF
--- a/src/FubarDev.WebDavServer.AspNetCore/FubarDev.WebDavServer.AspNetCore.csproj
+++ b/src/FubarDev.WebDavServer.AspNetCore/FubarDev.WebDavServer.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Scrutor" Version="3.1.0" />
+    <PackageReference Include="Scrutor" Version="4.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FubarDev.WebDavServer\FubarDev.WebDavServer.csproj" />


### PR DESCRIPTION
I got an error doing nuget restore with a net6 solution against the 2.0 branch, updating the scrutor depedency fixed that. 